### PR TITLE
vegman: show host's MAC addresses

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -34,6 +34,9 @@ if use_vegman_hack.enabled()
   conf.set_quoted('PCIE_ROOT_PATH', get_option('pcie-root-path'))
   conf.set_quoted('STORAGE_SERVICE', get_option('storage-service'))
   conf.set_quoted('STORAGE_ROOT_PATH', get_option('storage-root-path'))
+  conf.set_quoted('NET_ADAPTER_SERVICE', get_option('network-adapter-service'))
+  conf.set_quoted('NET_ADAPTER_ROOT_PATH',
+                  get_option('network-adapter-root-path'))
 endif
 configure_file(output: 'config.hpp', configuration: conf)
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -56,4 +56,9 @@ option('storage-service', type: 'string', value: 'com.yadro.Storage',
        description: 'Storage Manager service name')
 option('storage-root-path', type: 'string', value: '/',
        description: 'Storage Manager service root path')
+option('network-adapter-service', type: 'string',
+       value: 'com.yadro.NetworkAdapter',
+       description: 'Host\'s Network Adapters Manager service')
+option('network-adapter-root-path', type: 'string', value: '/',
+       description: 'Host\'s Network Adapters Manager service root path')
 

--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -178,6 +178,7 @@ std::vector<InventoryItem> getInventory(sdbusplus::bus::bus& bus)
             {SMBIOS_SERVICE, SMBIOS_ROOT_PATH},
             {PCIE_SERVICE, PCIE_ROOT_PATH},
             {STORAGE_SERVICE, STORAGE_ROOT_PATH},
+            {NET_ADAPTER_SERVICE, NET_ADAPTER_ROOT_PATH},
         };
 
     static const std::unordered_set<IfaceName> wantedIfaces{
@@ -189,6 +190,7 @@ std::vector<InventoryItem> getInventory(sdbusplus::bus::bus& bus)
         "xyz.openbmc_project.Inventory.Item.Cpu",
         "xyz.openbmc_project.Inventory.Item.Dimm",
         "xyz.openbmc_project.Inventory.Item.Drive",
+        "xyz.openbmc_project.Inventory.Item.NetworkInterface",
         "xyz.openbmc_project.PCIe.Device",
         "xyz.openbmc_project.State.Decorator.OperationalStatus",
     };


### PR DESCRIPTION
Previous commit excluded knowledge about the host's NIC MAC-addresses as
they cannot be associated with a corresponding PCI device. But this
breaks some tests and expectations. So we decided to restore them.

This commit adds support for `com.yadro.NetworkManager` that provides
the such info.

Signed-off-by: Alexander Filippov <a.filippov@yadro.com>